### PR TITLE
Remove old imports and use new folder structure

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,9 +10,9 @@ provider:
 package:
   include:
     - models
-    - connect.py
-    - berlin.py
-    - importer.py
+    - db
+    - cloud
+    - opendata
     - handler.py
     - requirements.txt
   exclude:


### PR DESCRIPTION
Make sure that the right folders/files are beeing imported.
I assumed that the python plugin was importing all files, but maybe it
does not, that's why I fixed the includes to includes only files that
are available and the correct folders